### PR TITLE
Only check for the local v4 or v6 address if needed

### DIFF
--- a/config.go
+++ b/config.go
@@ -59,3 +59,18 @@ func (r Record) invalid() bool {
 func (c PorkbunCredentials) invalid() bool {
 	return c.PorkbunAPIKey == "" || c.PorkbunSecretKey == ""
 }
+
+func ipNeeded(c configuration) (ipv4needed, ipv6needed bool) {
+	for _, record := range c.Records {
+		if record.IpV4 {
+			ipv4needed = true
+		}
+		if record.IpV6 {
+			ipv6needed = true
+		}
+		if ipv4needed && ipv6needed {
+			return
+		}
+	}
+	return
+}

--- a/main.go
+++ b/main.go
@@ -49,17 +49,29 @@ func setLogLevel(logLevel string) error {
 
 func updateRecords(c configuration) {
 	log.Info("Updating records")
-	ipv4address, err := getIpAddress(false)
-	if err != nil {
-		log.Error(err)
+	ipv4needed, ipv6needed := ipNeeded(c)
+	ipv4address := ""
+	if ipv4needed {
+		wtfIPv4address, err := getIpAddress(false)
+		if err != nil {
+			log.Error(err)
+		}
+		ipv4address = wtfIPv4address
+		log.Debugf("Current host ipv4: %s", ipv4address)
+	} else {
+		log.Debug("No ipv4 needed")
 	}
-	log.Debugf("Current host ipv4: %s", ipv4address)
-	ipv6address, err := getIpAddress(true)
-	if err != nil {
-		log.Error(err)
+	ipv6address := ""
+	if ipv6needed {
+		wtfIPv6address, err := getIpAddress(true)
+		if err != nil {
+			log.Error(err)
+		}
+		ipv6address = wtfIPv6address
+		log.Debugf("Current host ipv6: %s", ipv6address)
+	} else {
+		log.Debug("No ipv6 needed")
 	}
-	log.Debugf("Current host ipv6: %s", ipv6address)
-
 	ctx := context.Background()
 
 	for _, record := range c.Records {
@@ -69,10 +81,6 @@ func updateRecords(c configuration) {
 			continue
 		}
 		updateRecord(ctx, record, client, ipv4address, ipv6address)
-	}
-
-	if err != nil {
-		log.Error(err)
 	}
 	log.Info("Records updated")
 }


### PR DESCRIPTION
This change serves 2 purposes:
- We don't poll wtfismyip constantly for data we don't need
- If the network doesn't support any of the ip kinds, we just don't configure it. No extra flag/setting to disable any kind of ip is needed 