### PR TITLE
Add a metric that increases when the client can't resolve the current ip address

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -10,6 +10,13 @@ import (
 )
 
 var (
+	resolveErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "porkbun_resolve_errors_total",
+			Help: "The total number of errors trying to resolve the current ip address",
+		},
+		[]string{"record_type"},
+	)
 	updateErrorsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "porkbun_update_errors_total",

--- a/wtfismyip.go
+++ b/wtfismyip.go
@@ -49,6 +49,7 @@ func getIpAddresses(c configuration, wtfismyip WTFIsMyIPClient) (string, string)
 	if ipv4needed {
 		wtfIPv4address, err := wtfismyip.getIpAddress(false)
 		if err != nil {
+			resolveErrorsTotal.WithLabelValues("A").Inc()
 			log.Error(err)
 		}
 		ipv4address = wtfIPv4address
@@ -60,6 +61,7 @@ func getIpAddresses(c configuration, wtfismyip WTFIsMyIPClient) (string, string)
 	if ipv6needed {
 		wtfIPv6address, err := wtfismyip.getIpAddress(true)
 		if err != nil {
+			resolveErrorsTotal.WithLabelValues("AAAA").Inc()
 			log.Error(err)
 		}
 		ipv6address = wtfIPv6address


### PR DESCRIPTION
I wanted to add an ipv6 address to a record. I updated my configuration and nothing happened.
Turns out the system didn't have ipv6 configured and the only way to figure out this is failing is using the logs.
Using the metrics should be faster for alerting, so this introduces a new metric for that.