### PR TITLE
Skip cache in govulncheck action

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,4 +20,4 @@ jobs:
         with:
            go-version-file: go.mod
            go-package: ./...
-           check-latest: false
+           check-latest: true

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,3 +20,4 @@ jobs:
         with:
            go-version-file: go.mod
            go-package: ./...
+           cache: false

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,4 +20,4 @@ jobs:
         with:
            go-version-file: go.mod
            go-package: ./...
-           cache: false
+           check-latest: false


### PR DESCRIPTION
it's leading to false positives because it's not using the latest Go version