### PR TITLE
Separate connection errors in a different metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func updateRecords(c configuration) {
 	for _, record := range c.Records {
 		client, exists := clients[record.Credentials]
 		if !exists {
-			credentialsErrorTotal.Inc()
+			credentialsErrorsTotal.Inc()
 			log.Errorf("Credentials not found: %s", record.Credentials)
 			continue
 		}

--- a/metrics.go
+++ b/metrics.go
@@ -24,9 +24,13 @@ var (
 		},
 		[]string{"host", "domain"},
 	)
-	credentialsErrorTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "porkbun_credentials_error_total",
+	credentialsErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "porkbun_credentials_errors_total",
 		Help: "The total number of credentials errors",
+	})
+	connectionErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "porkbun_connection_errors_total",
+		Help: "The total number of connection errors (while connecting to porkbun)",
 	})
 	updateSuccessTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/porkbun.go
+++ b/porkbun.go
@@ -74,8 +74,8 @@ func getPorkbunClients(credentials map[string]PorkbunCredentials) (map[string]*p
 	for key, credential := range credentials {
 		client, err := getPorkbunClient(credential, key)
 		if err != nil {
-			credentialsErrorTotal.Inc()
-			log.Error(err)
+			connectionErrorsTotal.Inc()
+			log.Errorf("Error getting client for credentials '%s': %v", key, err)
 			continue
 		}
 		clients[key] = client


### PR DESCRIPTION
This PR introduces `connectionErrorsTotal` and renames `credentialsErrorTotal` to `credentialsErrorsTotal`.
this makes it easer to recognize when the problem is that credentials are not specified instead of just random connection problems to the porkbun API.