### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,4 +1,6 @@
 name: govulncheck
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/porkbun-ddns/security/code-scanning/2](https://github.com/jadolg/porkbun-ddns/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow or the specific job. Since the workflow only checks out code and runs a vulnerability scan, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. You can add this block either at the root of the workflow (to apply to all jobs) or within the `govulncheck` job itself. The best practice is to add it at the root level, immediately after the `name` and before the `on` block, to ensure all jobs inherit these minimal permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
