### PR TITLE
Sign Docker images and release binaries with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -18,6 +19,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4
       - name: Install Snapcraft
         run: |
           sudo snap install snapcraft --classic --channel edge
@@ -41,6 +44,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Login to Docker registry
@@ -51,7 +55,10 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
@@ -59,3 +66,7 @@ jobs:
           tags: ghcr.io/jadolg/porkbun-ddns:${{ github.sha }} , ghcr.io/jadolg/porkbun-ddns:latest , ghcr.io/jadolg/porkbun-ddns:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Sign Docker image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/jadolg/porkbun-ddns@${DIGEST}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,17 @@ archives:
         formats: [ zip ]
 checksum:
   name_template: 'checksums.txt'
+signs:
+  - cmd: cosign
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+      - '--yes'
+    artifacts: checksum
+    output: true
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 changelog:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,36 @@ Grab the binary for your system/architecture directly from the [release](https:/
 
 You can also just install from GitHub using Go directly `go install github.com/jadolg/porkbun-ddns@latest`
 
+## Verifying signatures
+
+Docker images and release binaries are signed in CI using [cosign](https://github.com/sigstore/cosign) keyless signing (Sigstore + GitHub OIDC). No public key is needed; verification checks the signing identity against this repository's release workflow.
+
+### Docker image
+
+```bash
+cosign verify ghcr.io/jadolg/porkbun-ddns:latest \
+  --certificate-identity-regexp '^https://github.com/jadolg/porkbun-ddns/.github/workflows/release.yml@refs/tags/.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+### Binaries
+
+Each release ships a `checksums.txt` along with its signature (`checksums.txt.sig`) and signing certificate (`checksums.txt.pem`). Download all three from the [release](https://github.com/jadolg/porkbun-ddns/releases) page next to the binary archive, then verify:
+
+```bash
+cosign verify-blob checksums.txt \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp '^https://github.com/jadolg/porkbun-ddns/.github/workflows/release.yml@refs/tags/.*$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+Once `checksums.txt` is verified, confirm your downloaded archive matches its checksum:
+
+```bash
+sha256sum --ignore-missing -c checksums.txt
+```
+
 ## Metrics
 
 To enable the collection of metrics, change the config file and set a valid port.


### PR DESCRIPTION
## Summary

Sign Docker images and release binaries in CI using [cosign](https://github.com/sigstore/cosign) keyless signing (Sigstore + GitHub OIDC). Signing only happens in CI — it relies on the workflow's OIDC token, and no private keys are stored anywhere.

- **`.goreleaser.yaml`** — added a `signs` block that signs `checksums.txt`, producing `checksums.txt.sig` + `checksums.txt.pem` as release artifacts (covers every binary archive).
- **`.github/workflows/release.yml`**
  - `goreleaser` job: `id-token: write` + `sigstore/cosign-installer@v4` (GoReleaser performs the signing).
  - `docker` job: `id-token: write`, cosign installer, and a step that runs `cosign sign` against the pushed image digest.
- **`README.md`** — new "Verifying signatures" section with `cosign verify` (image), `cosign verify-blob` (binaries via `checksums.txt`), and `sha256sum -c`.

## Verification (post-release)

```bash
cosign verify ghcr.io/jadolg/porkbun-ddns:latest \
  --certificate-identity-regexp '^https://github.com/jadolg/porkbun-ddns/.github/workflows/release.yml@refs/tags/.*$' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)