### PR TITLE
Test goreleaser build on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,24 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  goreleaser:
+    name: test goreleaser build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        distribution: goreleaser
+        version: '~> v2'
+        args: release --snapshot --clean --skip=publish,snapcraft


### PR DESCRIPTION
## What

Adds a `goreleaser` job to the PR build workflow that runs GoReleaser in snapshot mode to verify the release build succeeds without publishing anything.

## Why

Catch broken `.goreleaser.yaml` / build configs at PR time instead of discovering them during an actual release.

## Details

- `release --snapshot --clean --skip=publish,snapcraft` builds all artifacts (binaries, archives, deb/rpm) without publishing.
- `--snapshot` already disables publishing; `--skip=publish` is belt-and-suspenders.
- `--skip=snapcraft` avoids the slow snapcraft install on every PR.
- `fetch-depth: 0` so goreleaser can read git tags for versioning.