### PR TITLE
chore: update Go version to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS build
+FROM golang:1.26.6-alpine AS build
 
 RUN adduser --uid 1000 --disabled-password porkbun-ddns-user
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jadolg/porkbun-ddns
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/nrdcg/porkbun v0.4.0


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.6**.

### Changes
- go.mod: go 1.26.5 → go 1.26.6
- Dockerfile: golang:1.26.5 → golang:1.26.6

_Automated PR by update-go-version.sh_